### PR TITLE
use run.sh to set configuration path

### DIFF
--- a/app/configuration.py
+++ b/app/configuration.py
@@ -73,7 +73,7 @@ class Configuration:
         return self.mqtt_settings
 
     def get_modbus_settings(self) -> ModbusSettings:
-        return ModbusSettings(self.mqtt_settings.host, self.mqtt_settings.port)
+        return ModbusSettings(self.modbus_settings.host, self.modbus_settings.port)
 
 
 def path_to_yaml_data(path):

--- a/app/mqtt_client.py
+++ b/app/mqtt_client.py
@@ -24,14 +24,14 @@ class MqttClient:
         """
         this is a blocking operation.
         """
-        self.client.on_connect = self._on_connect
-        self.client.on_message = self._on_message
+        self.client.on_connect = self._on_connect()
+        self.client.on_message = self._on_message()
 
         self.client.connect(self.host, self.port)
         self.client.loop_forever()
 
     def _on_connect(self):
-        def inner(client, rc):
+        def inner(client, _userdata, _flags, rc):
             if rc == 0:
                 print("Connected to MQTT broker")
                 for topic in self.topics:
@@ -42,7 +42,7 @@ class MqttClient:
         return inner
 
     def _on_message(self):
-        def inner(message):
+        def inner(_client, _userdata, message):
             msg = _decode_message(message)
             for callback in self.on_message_callbacks:
                 callback(msg)

--- a/config/configuration.yml
+++ b/config/configuration.yml
@@ -1,10 +1,10 @@
 mqtt_settings:
-  host: "localhost"
-  port: 9000
+  host: "127.0.0.1"
+  port: 1883
   command_topic: "commands/#" # The mqtt topic that contains the relevant commands.
 
 modbus_settings:
-  host: "localhost"
+  host: "127.0.0.1"
   port: 8080
 
 modbus_mapping:

--- a/dockerfile
+++ b/dockerfile
@@ -7,13 +7,14 @@ FROM python as poetry
 ENV POETRY_HOME=/opt/poetry
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 ENV PATH="$POETRY_HOME/bin:$PATH"
+ENV CONFIGURATION_PATH="config/configuration.yml"
 RUN python -c 'from urllib.request import urlopen; print(urlopen("https://install.python-poetry.org").read().decode())' | python -
 COPY . ./
 RUN poetry install --no-interaction --no-ansi -vvv
 
 
-
 FROM python as runtime
 ENV PATH="/app/.venv/bin:$PATH"
+
 COPY --from=poetry /app /app
-CMD [ "python", "./main.py" ]
+CMD "./run.sh"

--- a/main.py
+++ b/main.py
@@ -33,14 +33,15 @@ def get_configuration_with_overrides(args):
     modbus_settings = configuration.get_modbus_settings()
 
     mqtt_settings_with_override = MqttSettings(
-        args_as_dict.get("mqtt_host", mqtt_settings.host),
-        args_as_dict.get("mqtt_port", mqtt_settings.port),
-        args_as_dict.get("mqtt_topic", mqtt_settings.command_topic),
+        args_as_dict.get("mqtt_host") or mqtt_settings.host,
+        args_as_dict.get("mqtt_port") or mqtt_settings.port,
+        args_as_dict.get("mqtt_topic") or mqtt_settings.command_topic,
     )
 
+
     modbus_settings_with_override = ModbusSettings(
-        args_as_dict.get("modbus_host", modbus_settings.host),
-        args_as_dict.get("modbus_port", modbus_settings.port),
+        args_as_dict.get("modbus_host") or modbus_settings.host,
+        args_as_dict.get("modbus_port") or modbus_settings.port,
     )
 
     return Configuration(

--- a/main.py
+++ b/main.py
@@ -9,7 +9,8 @@ from app.configuration import Configuration, ModbusSettings, MqttSettings
 
 def handle_args():
     # Create the argument parser
-    parser = argparse.ArgumentParser(description='remote commands handler')
+    parser = argparse.ArgumentParser(description='remote commands handler',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     # Add the optional arguments
     parser.add_argument('--configuration_path', required=True,
@@ -21,8 +22,6 @@ def handle_args():
     parser.add_argument('--mqtt_port', type=int, help='The port number for the MQTT server. Expected to be an integer.')
     parser.add_argument('--mqtt_host', help='The host address for the MQTT server. Expected to be a string.')
     parser.add_argument('--mqtt_topic', help='The MQTT topic to subscribe to. Expected to be a string.')
-    parser = argparse.ArgumentParser(description='remote commands handler',
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     return parser.parse_args()
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+python3 main.py --configuration_path $CONFIGURATION_PATH

--- a/tests/config/configuration_test.py
+++ b/tests/config/configuration_test.py
@@ -64,8 +64,8 @@ def test_able_to_get_modbus_settings():
 
     modbus_settings = configuration.get_modbus_settings()
 
-    assert modbus_settings.port == 9000
-    assert modbus_settings.host == "mqtt.host"
+    assert modbus_settings.port == 8080
+    assert modbus_settings.host == "modbus.host"
 
 
 def test_get_coils():


### PR DESCRIPTION
Use of a bash script allows us to use env variables in the docker and docker-compose to more easily set the configuration path variable.