### PR TITLE
Ensure we use semver when we publish new tags

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -28,7 +28,10 @@ jobs:
           images: |
             ghcr.io/${{ github.repository }}
           tags: |
+            type=ref,event=branch
+            type=ref,event=tag
             type=sha
+            type=semver,pattern={{version}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -27,6 +27,8 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository }}
+          flavor: |
+                latest=${{ github.ref == 'refs/heads/main' }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag

--- a/app/modbus_client.py
+++ b/app/modbus_client.py
@@ -3,24 +3,26 @@ from app.configuration import Configuration
 
 
 class ModbusClient:
+    _client: ModbusTcpClient
+
     def __init__(self, configuration: Configuration, port: int, host: str) -> None:
         self.configuration = configuration
-        self.client = ModbusTcpClient(host, port=port)
+        self._client = ModbusTcpClient(host, port=port)
 
     def write_coils(self, name: str, value: list[bool]):
         coil_configuration = self.configuration.get_coil(name)
-        self.client.connect()
-        self.client.write_coils(coil_configuration.address[0], value)
-        self.client.close()
+        self._client.connect()
+        self._client.write_coils(coil_configuration.address[0], value)
+        self._client.close()
 
     def write_coil(self, name: str, value: bool):
         coil_configuration = self.configuration.get_coil(name)
-        self.client.connect()
-        self.client.write_coil(coil_configuration.address[0], value)
-        self.client.close()
+        self._client.connect()
+        self._client.write_coil(coil_configuration.address[0], value)
+        self._client.close()
 
     def write_register(self, name: str, value):
         holding_register_configuration = self.configuration.get_holding_register(name)
-        self.client.connect()
-        self.client.write_register(holding_register_configuration.address[0], value)
-        self.client.close()
+        self._client.connect()
+        self._client.write_register(holding_register_configuration.address[0], value)
+        self._client.close()

--- a/config/configuration.yml
+++ b/config/configuration.yml
@@ -1,11 +1,11 @@
 mqtt_settings:
-  host: "127.0.0.1"
+  host: "localhost"
   port: 1883
   command_topic: "commands/#" # The mqtt topic that contains the relevant commands.
 
 modbus_settings:
-  host: "127.0.0.1"
-  port: 8080
+  host: "localhost"
+  port: 502
 
 modbus_mapping:
   holding_registers:


### PR DESCRIPTION
## What?

* Use semver when we publish new tags
* Use branch name when we publish to main
* Update default ports using sensible values
* Flag the ModbusClient private