### PR TITLE
Replace CMD with ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ FROM python as runtime
 ENV PATH="/app/.venv/bin:$PATH"
 
 COPY --from=poetry /app /app
-CMD "./run.sh"
+ENTRYPOINT ["./run.sh"]

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -8,6 +8,18 @@ modbus_settings:
   port: 502
 
 modbus_mapping:
+  ## name        - the variable name
+  ## byte_order  - the ordering of bytes
+  ##  |---AB, ABCD   - Big Endian
+  ##  |---BA, DCBA   - Little Endian
+  ##  |---BADC       - Mid-Big Endian
+  ##  |---CDAB       - Mid-Little Endian
+  ## data_type   - INT8L, INT8H, UINT8L, UINT8H (low and high byte variants)
+  ##               INT16, UINT16, INT32, UINT32, INT64, UINT64,
+  ##               FLOAT16-IEEE, FLOAT32-IEEE, FLOAT64-IEEE (IEEE 754 binary representation)
+  ##               FLOAT32, FIXED, UFIXED (fixed-point representation on input)
+  ## scale       - the final numeric variable representation
+  ## address     - variable address
   holding_registers:
     - name: "evgBatteryMode"
       byte_order: "AB" # Fill this in

--- a/run.sh
+++ b/run.sh
@@ -2,8 +2,8 @@
 
 if [ -z "$CONFIGURATION_PATH" ]
 then
-    python3 main.py
+    python3 main.py "$@"
 else
-    python3 main.py --configuration_path $CONFIGURATION_PATH
+    python3 main.py --configuration_path $CONFIGURATION_PATH "$@"
 fi
 


### PR DESCRIPTION
## What?

* Replace CMD with ENTRYPOINT
* Add better documentation to the config file
* Allow to propagate configuration values from CLI

## Why?

The current CMD is not allowing to pass the values. Quoting GPT:

> The difference between CMD and ENTRYPOINT is that CMD sets default command and/or parameters which can be overwritten from the command line when docker container runs, while ENTRYPOINT command and parameters will not be overwritten from the command line.


## Testing/Proof

```
 docker run serroba/remote-commands-handler:local --mqtt_host=mqtt

Traceback (most recent call last):
  File "/app/app/mqtt_client.py", line 33, in run
    self._client.connect(self.host, self.port)
  File "/app/.venv/lib/python3.11/site-packages/paho/mqtt/client.py", line 914, in connect
    return self.reconnect()
           ^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/paho/mqtt/client.py", line 1044, in reconnect
    sock = self._create_socket_connection()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/paho/mqtt/client.py", line 3685, in _create_socket_connection
    return socket.create_connection(addr, timeout=self._connect_timeout, source_address=source)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/socket.py", line 827, in create_connection
    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/socket.py", line 962, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
socket.gaierror: [Errno -2] Name or service not known

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/main.py", line 91, in <module>
    main()
  File "/app/main.py", line 87, in main
    mqtt_client.run()
  File "/app/app/mqtt_client.py", line 35, in run
    raise OSError(f"Cannot assign requested address: {self.host}:{self.port}") from e
OSError: Cannot assign requested address: mqtt:1883

```

It's an error the above, but we can see that the host is actually being used via CLI `mqtt` is the host I proved.