### PR TITLE
Adding black as a (auto)linter for some things that pylint doesn't cover

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,9 @@ jobs:
       - name: Lint with pylint
         run: |
           poetry run pylint -E --rcfile=./.pylintrc app/ main.py
+      - name: Check code formatting with Black
+        run: |
+          poetry run black --check .
       - name: Test with pytest
         run: |
           poetry run pytest

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -35,13 +35,12 @@ class ModbusSettings:
 
 
 class Configuration:
-
     def __init__(
-            self,
-            coils: list[Coil],
-            holding_registers: list[HoldingRegister],
-            mqtt_settings: MqttSettings,
-            modbus_settings: ModbusSettings,
+        self,
+        coils: list[Coil],
+        holding_registers: list[HoldingRegister],
+        mqtt_settings: MqttSettings,
+        modbus_settings: ModbusSettings,
     ):
         self.coils_map = {x.name: x for x in coils}
         self.holding_register_map = {x.name: x for x in holding_registers}
@@ -89,15 +88,24 @@ def _modbus_settings_from_yaml_data(data) -> ModbusSettings:
 
 def _mqtt_settings_from_yaml_data(data) -> MqttSettings:
     mqtt_settings = data["mqtt_settings"]
-    return MqttSettings(mqtt_settings["host"], mqtt_settings["port"], mqtt_settings["command_topic"])
+    return MqttSettings(
+        mqtt_settings["host"], mqtt_settings["port"], mqtt_settings["command_topic"]
+    )
 
 
 def _coils_data_from_yaml_data(data):
     modbus_mapping = data.get("modbus_mapping", {})
-    coils = [Coil(coil["name"], coil["address"]) for coil in modbus_mapping.get("coils", [])]
+    coils = [
+        Coil(coil["name"], coil["address"]) for coil in modbus_mapping.get("coils", [])
+    ]
     holding_registers = [
-        HoldingRegister(register["name"], register["byte_order"], register["data_type"], register["scale"],
-                        register["address"])
+        HoldingRegister(
+            register["name"],
+            register["byte_order"],
+            register["data_type"],
+            register["scale"],
+            register["address"],
+        )
         for register in modbus_mapping.get("holding_registers", [])
     ]
 

--- a/app/modbus_client.py
+++ b/app/modbus_client.py
@@ -5,7 +5,9 @@ from app.configuration import Configuration
 class ModbusClient:
     _client: ModbusTcpClient
 
-    def __init__(self, configuration: Configuration, modbus_client: ModbusTcpClient) -> None:
+    def __init__(
+        self, configuration: Configuration, modbus_client: ModbusTcpClient
+    ) -> None:
         self.configuration = configuration
         self._client = modbus_client
 

--- a/app/mqtt_client.py
+++ b/app/mqtt_client.py
@@ -32,7 +32,9 @@ class MqttClient:
         try:
             self._client.connect(self.host, self.port)
         except OSError as e:
-            raise OSError(f"Cannot assign requested address: {self.host}:{self.port}") from e
+            raise OSError(
+                f"Cannot assign requested address: {self.host}:{self.port}"
+            ) from e
 
         self._client.loop_forever()
 

--- a/main.py
+++ b/main.py
@@ -13,19 +13,38 @@ from app.configuration import Configuration, ModbusSettings, MqttSettings
 
 def handle_args():
     # Create the argument parser
-    parser = argparse.ArgumentParser(description='remote commands handler',
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description="remote commands handler",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
     # Add the optional arguments
-    parser.add_argument('--configuration_path',
-                        help='Path to the configuration file. By default, this is "config/configuration.yaml".',
-                        default='config/configuration.yaml')
-    parser.add_argument('--modbus_port', type=int,
-                        help='The port number for the Modbus server. Expected to be an integer.')
-    parser.add_argument('--modbus_host', help='The host address for the Modbus server. Expected to be a string.')
-    parser.add_argument('--mqtt_port', type=int, help='The port number for the MQTT server. Expected to be an integer.')
-    parser.add_argument('--mqtt_host', help='The host address for the MQTT server. Expected to be a string.')
-    parser.add_argument('--mqtt_topic', help='The MQTT topic to subscribe to. Expected to be a string.')
+    parser.add_argument(
+        "--configuration_path",
+        help='Path to the configuration file. By default, this is "config/configuration.yaml".',
+        default="config/configuration.yaml",
+    )
+    parser.add_argument(
+        "--modbus_port",
+        type=int,
+        help="The port number for the Modbus server. Expected to be an integer.",
+    )
+    parser.add_argument(
+        "--modbus_host",
+        help="The host address for the Modbus server. Expected to be a string.",
+    )
+    parser.add_argument(
+        "--mqtt_port",
+        type=int,
+        help="The port number for the MQTT server. Expected to be an integer.",
+    )
+    parser.add_argument(
+        "--mqtt_host",
+        help="The host address for the MQTT server. Expected to be a string.",
+    )
+    parser.add_argument(
+        "--mqtt_topic", help="The MQTT topic to subscribe to. Expected to be a string."
+    )
 
     return parser.parse_args()
 
@@ -57,15 +76,21 @@ def get_configuration_with_overrides(args):
 
 
 def setup_modbus_client(configuration: Configuration) -> ModbusClient:
-    return ModbusClient(configuration, ModbusTcpClient(
-        configuration.get_modbus_settings().host,
-        port=configuration.get_modbus_settings().port))
+    return ModbusClient(
+        configuration,
+        ModbusTcpClient(
+            configuration.get_modbus_settings().host,
+            port=configuration.get_modbus_settings().port,
+        ),
+    )
 
 
 def setup_mqtt_client(configuration: Configuration) -> MqttClient:
-    return MqttClient(configuration.get_mqtt_settings().port,
-                      configuration.get_mqtt_settings().host,
-                      mqtt.Client())
+    return MqttClient(
+        configuration.get_mqtt_settings().port,
+        configuration.get_mqtt_settings().host,
+        mqtt.Client(),
+    )
 
 
 def main():
@@ -87,5 +112,5 @@ def main():
     mqtt_client.run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/poetry.lock
+++ b/poetry.lock
@@ -17,6 +17,69 @@ lazy-object-proxy = ">=1.4.0"
 wrapt = {version = ">=1.14,<2", markers = "python_version >= \"3.11\""}
 
 [[package]]
+name = "black"
+version = "23.3.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "black-23.3.0-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:0945e13506be58bf7db93ee5853243eb368ace1c08a24c65ce108986eac65915"},
+    {file = "black-23.3.0-cp310-cp310-macosx_10_16_universal2.whl", hash = "sha256:67de8d0c209eb5b330cce2469503de11bca4085880d62f1628bd9972cc3366b9"},
+    {file = "black-23.3.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:7c3eb7cea23904399866c55826b31c1f55bbcd3890ce22ff70466b907b6775c2"},
+    {file = "black-23.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32daa9783106c28815d05b724238e30718f34155653d4d6e125dc7daec8e260c"},
+    {file = "black-23.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:35d1381d7a22cc5b2be2f72c7dfdae4072a3336060635718cc7e1ede24221d6c"},
+    {file = "black-23.3.0-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:a8a968125d0a6a404842fa1bf0b349a568634f856aa08ffaff40ae0dfa52e7c6"},
+    {file = "black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b"},
+    {file = "black-23.3.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:a6f6886c9869d4daae2d1715ce34a19bbc4b95006d20ed785ca00fa03cba312d"},
+    {file = "black-23.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f3c333ea1dd6771b2d3777482429864f8e258899f6ff05826c3a4fcc5ce3f70"},
+    {file = "black-23.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:11c410f71b876f961d1de77b9699ad19f939094c3a677323f43d7a29855fe326"},
+    {file = "black-23.3.0-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:1d06691f1eb8de91cd1b322f21e3bfc9efe0c7ca1f0e1eb1db44ea367dff656b"},
+    {file = "black-23.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50cb33cac881766a5cd9913e10ff75b1e8eb71babf4c7104f2e9c52da1fb7de2"},
+    {file = "black-23.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e114420bf26b90d4b9daa597351337762b63039752bdf72bf361364c1aa05925"},
+    {file = "black-23.3.0-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:48f9d345675bb7fbc3dd85821b12487e1b9a75242028adad0333ce36ed2a6d27"},
+    {file = "black-23.3.0-cp38-cp38-macosx_10_16_universal2.whl", hash = "sha256:714290490c18fb0126baa0fca0a54ee795f7502b44177e1ce7624ba1c00f2331"},
+    {file = "black-23.3.0-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:064101748afa12ad2291c2b91c960be28b817c0c7eaa35bec09cc63aa56493c5"},
+    {file = "black-23.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:562bd3a70495facf56814293149e51aa1be9931567474993c7942ff7d3533961"},
+    {file = "black-23.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:e198cf27888ad6f4ff331ca1c48ffc038848ea9f031a3b40ba36aced7e22f2c8"},
+    {file = "black-23.3.0-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:3238f2aacf827d18d26db07524e44741233ae09a584273aa059066d644ca7b30"},
+    {file = "black-23.3.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"},
+    {file = "black-23.3.0-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:92c543f6854c28a3c7f39f4d9b7694f9a6eb9d3c5e2ece488c327b6e7ea9b266"},
+    {file = "black-23.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a150542a204124ed00683f0db1f5cf1c2aaaa9cc3495b7a3b5976fb136090ab"},
+    {file = "black-23.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:6b39abdfb402002b8a7d030ccc85cf5afff64ee90fa4c5aebc531e3ad0175ddb"},
+    {file = "black-23.3.0-py3-none-any.whl", hash = "sha256:ec751418022185b0c1bb7d7736e6933d40bbb14c14a0abcf9123d1b159f98dd4"},
+    {file = "black-23.3.0.tar.gz", hash = "sha256:1c7b8d606e728a41ea1ccbd7264677e494e87cf630e399262ced92d4a8dac940"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -132,6 +195,18 @@ files = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
@@ -156,6 +231,18 @@ files = [
 
 [package.extras]
 proxy = ["PySocks"]
+
+[[package]]
+name = "pathspec"
+version = "0.11.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
+    {file = "pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
+]
 
 [[package]]
 name = "platformdirs"
@@ -423,4 +510,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "a7ee56ee50223845a9478d6f4de6b861e397812dc343d0d5e70463346b5d2d20"
+content-hash = "b61098f6ca242079a9bc5c5585523bf55753e82f1a249a5dcba45dacabf13830"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,12 @@ packages = [{include = "main.py"}]
 python = "^3.11"
 pymodbus = "^3.2.2"
 paho-mqtt = "^1.6.1"
-pylint = "^2.17.4"
-pytest = "^7.3.1"
 pyyaml = "^6.0"
 
+[tool.poetry.group.dev.dependencies]
+black = "^23.3.0"
+pylint = "^2.17.4"
+pytest = "^7.3.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/app/test_modbus_client.py
+++ b/tests/app/test_modbus_client.py
@@ -6,15 +6,22 @@ from multiprocessing import Pipe
 from pymodbus.client import ModbusTcpClient
 
 from app.modbus_client import ModbusClient
-from app.configuration import Coil, Configuration, HoldingRegister, ModbusSettings, MqttSettings
+from app.configuration import (
+    Coil,
+    Configuration,
+    HoldingRegister,
+    ModbusSettings,
+    MqttSettings,
+)
 
 
 class TestModbusClient(unittest.TestCase):
-
     def setUp(self):
         # This method will be called before every test
         self.coils = [Coil("test_coil", [1])]
-        self.holding_registers = [HoldingRegister("test_register", "AB", "INT16", 1.0, [1])]
+        self.holding_registers = [
+            HoldingRegister("test_register", "AB", "INT16", 1.0, [1])
+        ]
         self.mqtt_settings = MqttSettings("test", 100, "test")
 
     def start_local_tcp_client(self, f):
@@ -46,7 +53,9 @@ class TestModbusClient(unittest.TestCase):
         # Accept a client connection
         client_socket, _ = server_socket.accept()
         # Create a new thread to handle the client connection
-        client_thread = threading.Thread(target=self.handle_socket_message, args=(client_socket, f))
+        client_thread = threading.Thread(
+            target=self.handle_socket_message, args=(client_socket, f)
+        )
         client_thread.start()
         return port
 
@@ -58,7 +67,9 @@ class TestModbusClient(unittest.TestCase):
 
         thread, port = self.start_local_tcp_client(test)
         modbus_settings = ModbusSettings("localhost", port)
-        configuration = Configuration(self.coils, [], self.mqtt_settings, modbus_settings)
+        configuration = Configuration(
+            self.coils, [], self.mqtt_settings, modbus_settings
+        )
         client = ModbusClient(configuration, ModbusTcpClient("localhost", port=port))
         client.write_coil("test_coil", True)
         sent = read.recv()
@@ -73,7 +84,9 @@ class TestModbusClient(unittest.TestCase):
 
         thread, port = self.start_local_tcp_client(test)
         modbus_settings = ModbusSettings("localhost", port)
-        configuration = Configuration(self.coils, [], self.mqtt_settings, modbus_settings)
+        configuration = Configuration(
+            self.coils, [], self.mqtt_settings, modbus_settings
+        )
         client = ModbusClient(configuration, ModbusTcpClient("localhost", port=port))
         client.write_coils("test_coil", [True, True])
         sent = read.recv()
@@ -89,7 +102,9 @@ class TestModbusClient(unittest.TestCase):
 
         thread, port = self.start_local_tcp_client(test)
         modbus_settings = ModbusSettings("localhost", port)
-        configuration = Configuration([], self.holding_registers, self.mqtt_settings, modbus_settings)
+        configuration = Configuration(
+            [], self.holding_registers, self.mqtt_settings, modbus_settings
+        )
         client = ModbusClient(configuration, ModbusTcpClient("localhost", port=port))
         client.write_register("test_register", 10)
         sent = read.recv()
@@ -97,5 +112,5 @@ class TestModbusClient(unittest.TestCase):
         self.assertTrue(sent)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/app/test_mqtt_client.py
+++ b/tests/app/test_mqtt_client.py
@@ -7,7 +7,9 @@ from app.mqtt_client import MqttClient
 class TestMqttClient(unittest.TestCase):
     def setUp(self):
         self.mock_mqtt_client = MagicMock(spec=mqtt.Client)
-        self.mqtt_client = MqttClient(port=1883, host='localhost', client=self.mock_mqtt_client)
+        self.mqtt_client = MqttClient(
+            port=1883, host="localhost", client=self.mock_mqtt_client
+        )
 
     def test_run(self):
         # Assume connect method always successful
@@ -17,8 +19,8 @@ class TestMqttClient(unittest.TestCase):
         self.mqtt_client.run()
 
         # Verify that connect was called with the correct parameters
-        self.mock_mqtt_client.connect.assert_called_with('localhost', 1883)
+        self.mock_mqtt_client.connect.assert_called_with("localhost", 1883)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/config/configuration_test.py
+++ b/tests/config/configuration_test.py
@@ -3,7 +3,13 @@ import os
 
 import pytest
 
-from app.configuration import Coil, Configuration, HoldingRegister, ModbusSettings, MqttSettings
+from app.configuration import (
+    Coil,
+    Configuration,
+    HoldingRegister,
+    ModbusSettings,
+    MqttSettings,
+)
 from app.exceptions import ConfigurationFileNotFoundError
 
 
@@ -13,7 +19,6 @@ def test_throws_exception_when_configuration_file_not_found():
 
 
 def test_get_coil():
-
     configuration = Configuration.from_file(_config_path())
 
     evg_battery_mode_coil_address = configuration.get_coil("evgBatteryModeCoil")
@@ -40,7 +45,9 @@ def test_get_holding_registers():
     assert evg_battery_mode.scale == 1.0
     assert evg_battery_mode.address == [0]
 
-    evg_battery_target_soc_percent = configuration.get_holding_register("evgBatteryTargetSOCPercent")
+    evg_battery_target_soc_percent = configuration.get_holding_register(
+        "evgBatteryTargetSOCPercent"
+    )
 
     assert evg_battery_target_soc_percent.name == "evgBatteryTargetSOCPercent"
     assert evg_battery_target_soc_percent.byte_order == "AB"
@@ -69,24 +76,24 @@ def test_able_to_get_modbus_settings():
 
 
 def test_get_coils():
-    coils = [
-        Coil("test_coil", 1)
-    ]
+    coils = [Coil("test_coil", 1)]
     holding_registers = []
     mqtt_settings = MqttSettings("test", 100, "test")
     modbus_settings = ModbusSettings("localhost", 10)
-    configuration = Configuration(coils, holding_registers, mqtt_settings, modbus_settings)
+    configuration = Configuration(
+        coils, holding_registers, mqtt_settings, modbus_settings
+    )
 
     assert coils == configuration.get_coils()
 
 
 def test_get_registers():
     coils = []
-    holding_registers = [
-        HoldingRegister("test", "AB", "STR", 1.0, [0])
-    ]
+    holding_registers = [HoldingRegister("test", "AB", "STR", 1.0, [0])]
     mqtt_settings = MqttSettings("test", 100, "test")
     modbus_settings = ModbusSettings("localhost", 10)
-    configuration = Configuration(coils, holding_registers, mqtt_settings, modbus_settings)
+    configuration = Configuration(
+        coils, holding_registers, mqtt_settings, modbus_settings
+    )
 
     assert holding_registers == configuration.get_holding_registers()


### PR DESCRIPTION
## What?

* Adding black as linter
* Update files accordingly
* 
## Why?

Black is a good tool to respect PEP 8, including enforcement of empty new lines on python file

## Testing/Proof

If I now have this:
```
diff --git a/app/mqtt_client.py b/app/mqtt_client.py
index 54bab8b..87a677e 100644
--- a/app/mqtt_client.py
+++ b/app/mqtt_client.py
@@ -55,4 +55,4 @@ class MqttClient:
             for callback in self.on_message_callbacks:
                 callback(msg)
 
-        return inner
+        return inner
\ No newline at end of file
```

When I run `poetry run black --check .` I get:

```
(remote-comands-handler-py3.11) ➜  remote-commands-handler git:(linting-black) ✗ poetry run black --check .
would reformat /Users/sebastianmachuca/projects/remote-commands-handler/app/mqtt_client.py

Oh no! 💥 💔 💥
1 file would be reformatted, 7 files would be left unchanged.
```