### PR TITLE
Enable logging rather than print

### DIFF
--- a/app/mqtt_client.py
+++ b/app/mqtt_client.py
@@ -1,3 +1,5 @@
+import logging
+
 import paho.mqtt.client as mqtt
 
 
@@ -39,11 +41,11 @@ class MqttClient:
     def _on_connect(self):
         def inner(client, _userdata, _flags, rc):
             if rc == 0:
-                print("Connected to MQTT broker")
+                logging.info("Connected to MQTT broker")
                 for topic in self.topics:
                     client.subscribe(topic)
             else:
-                print("Connection failed")
+                logging.error("Connection failed")
 
         return inner
 

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import json
 
@@ -69,6 +70,8 @@ def setup_mqtt_client(configuration: Configuration) -> MqttClient:
 
 
 def main():
+    loglevel = os.getenv("LOGLEVEL", "INFO").upper()
+    logging.basicConfig(level=getattr(logging, loglevel))
     args = handle_args()
 
     configuration = get_configuration_with_overrides(args)

--- a/tests/app/test_modbus_client.py
+++ b/tests/app/test_modbus_client.py
@@ -84,7 +84,6 @@ class TestModbusClient(unittest.TestCase):
         read, write = Pipe(duplex=False)
 
         def test(_message):
-            print(_message)
             write.send(True)
 
         thread, port = self.start_local_tcp_client(test)


### PR DESCRIPTION
## What?

Enable logging
## Why?

We shouldn't be using `print`. Logging allow us to differentiate levels
